### PR TITLE
colour html and html inside template literals (literally-html extension)

### DIFF
--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -178,7 +178,28 @@
         "foreground": "#91c5d3"
       }
     },
-
+    {
+      "name": "HTML tag",
+      "scope": "meta.tag, punctuation.definition.tag.html, punctuation.definition.tag.begin.html, punctuation.definition.tag.end.html",
+      "settings": {
+        "foreground": "#7F7F7F",
+      }
+    },
+    {
+      "name": "HTML tag name",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#91c5d3",
+      }
+    },
+    {
+      "name": "HTML tag name attribute",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#ffe2a9",
+        "fontStyle": "italic",
+      }
+    },
     {
       "name": "Inserted",
       "scope": "markup.inserted",


### PR DESCRIPTION
The EJS file in the screenshots was autodetected as HTML.

![image](https://user-images.githubusercontent.com/5485639/39542312-7f773e36-4e48-11e8-8d6b-218c1771ce15.png)

after

![image](https://user-images.githubusercontent.com/5485639/39542328-8d6dd75c-4e48-11e8-973d-20f57600c6bd.png)
