### PR TITLE
TypeScript support, Demo files and separate italic theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 *.vsix
 .DS_Store
-test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.vsix
 .DS_Store
+test

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,3 +2,4 @@
 .vscode-test/**
 .gitignore
 vsc-extension-quickstart.md
+demo/**

--- a/demo/sample.css
+++ b/demo/sample.css
@@ -1,0 +1,68 @@
+body {
+    font-family: arial;
+}
+
+h1,
+p,
+table {
+    background-color: #CCC;
+    border: 1px solid;
+    color: #39F;
+    text-align: center;
+    width: 100%;
+}
+
+.addon-store .pagehead h1 {
+    display: inline-block
+}
+
+.addon-store .addon-summary:after {
+    clear: both
+}
+
+#addon-store .pagehead .electrocat-small {
+    bottom: -7px;
+    position: absolute;
+    right: 0;
+}
+
+.addon-store .addons-nav a.selected {
+    border-bottom-color: #d26911;
+    color: #333;
+    font-weight: bold;
+    padding: 0 0 14px;
+}
+
+.addon-store .addon-icon {
+    background: #fff;
+    border: 1px solid #ddd;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+    float: left;
+    height: 80px;
+    margin-right: 14px;
+    width: 80px;
+}
+
+.addon-store .developer-callout {
+    background-color: #f1f1f1;
+    background-image: -moz-linear-gradient(#fafafa, #f1f1f1);
+    background-image: -webkit-linear-gradient(#fafafa, #f1f1f1);
+    background-image: linear-gradient(#fafafa, #f1f1f1);
+    background-repeat: repeat-x;
+    border: 1px solid #ddd;
+    border-bottom: 1px solid #ccc;
+    border-radius: 3px;
+    box-shadow: inset 0 1px 0 #fff, 0 1px 5px #f1f1f1;
+    margin-top: 40px;
+    text-shadow: 0 1px 0 #fff;
+}
+
+.addon-field-editor .addon-field-list,
+.addon-field-editor .addon-new-field {
+    -moz-box-sizing: border-box;
+    border-radius: 3px;
+    box-sizing: border-box;
+    display: inline-block;
+    text-align: center;
+    width: 595px;
+}

--- a/demo/sample.html
+++ b/demo/sample.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <!-- Meta, title, CSS, favicons, etc. -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <title>Bootstrap</title>
+
+    <!-- Bootstrap core CSS -->
+    <link href="./dist/css/bootstrap.css" rel="stylesheet">
+
+    <!-- Documentation extras -->
+    <link href="./assets/css/docs.css" rel="stylesheet">
+    <link href="./assets/css/pygments-manni.css" rel="stylesheet">
+
+    <link rel="shortcut icon" href="./assets/ico/favicon.png">
+</head>
+
+<body class="bs-docs-home">
+
+    <!-- Docs master nav -->
+    <div class="navbar navbar-inverse navbar-fixed-top bs-docs-nav">
+        <div class="container">
+            <a href="./" class="navbar-brand">Bootstrap 3 RC1</a>
+            <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <div class="nav-collapse collapse bs-navbar-collapse">
+                <ul class="nav navbar-nav">
+                    <li>
+                        <a href="./getting-started">Getting started</a>
+                    </li>
+                    <li>
+                        <a href="./css">CSS</a>
+                    </li>
+                    <li>
+                        <a href="./components">Components</a>
+                    </li>
+                    <li>
+                        <a href="./javascript">JavaScript</a>
+                    </li>
+                    <li>
+                        <a href="./customize">Customize</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- Page content of course! -->
+    <div class="bs-masthead">
+        <div class="container">
+            <h1>Bootstrap 3</h1>
+            <p class="lead">Sleek, intuitive, and powerful mobile-first front-end framework for faster and easier web development.</p>
+            <p>
+                <a href="http://getbootstrap.com/bs-v3.0.0-rc1-dist.zip" class="btn btn-bs btn-large" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Download', 'Download 3.0.0 RC1']);">Download Bootstrap</a>
+            </p>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/demo/sample.js
+++ b/demo/sample.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+('use strict');
+
+(global => {
+  'use strict';
+
+  const links = Array.from(document.querySelectorAll('a[href="#0"]'));
+
+  links.forEach(link => {
+    link.addEventListener('click', event => {
+      event.preventDefault();
+    });
+  });
+
+  const input = document.querySelector('input');
+
+  input.addEventListener('focus', () => {
+    input.setAttribute('placeholder', '');
+  });
+})(typeof window !== 'undefined' ? window : global);

--- a/demo/sample.jsx
+++ b/demo/sample.jsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+export class Test extends React.Component<{bar: string}, {}>{
+  render(){
+    return (
+      <div foo={this.props.bar} bar={true} baz={'str'} boz={"other str"}></div>
+    );
+  }
+}
+
+import * as styles from './mission.scss';
+
+export default function MissionIcon({ key, title }) {
+  return <i class={classnames(
+    styles['mission__icon'],
+    {
+      [styles['mission__icon-letter']]: title.match(A_HEBREW_LETTER),
+      [styles['mission__icon-first']]: !key,
+    }
+  )}>{title}</i>;
+}
+
+@connect(
+  ({ artists }) => ({ artists }),
+  dispatch => bindActionCreators({ getArtists, getArtist, addArtist, editArtist, removeArtist }, dispatch)
+)
+export default class AdminArtists extends Component {
+
+  componentWillMount = () => {
+    this.props.getArtists();
+  }
+
+  render = () => {
+    console.log(this.props.artists);
+    return <div>
+    </div>;
+  }
+}

--- a/demo/sample.ts
+++ b/demo/sample.ts
@@ -1,0 +1,84 @@
+import * as vscode from 'vscode';
+import { CanIUse } from './can-i-use';
+
+interface Sample {
+  type: string | undefined;
+  name?: string;
+  click(): void;
+  callback: () => void;
+}
+
+type SampleType = {
+  myType: string;
+};
+
+export function activate(context: vscode.ExtensionContext) {
+  var disposable = vscode.commands.registerCommand('extension.canIUse', () => {
+    let caniuse = new CanIUse();
+
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return;
+    }
+    var expandedSelection = undefined;
+    expandedSelection = getSelection(editor);
+    if (expandedSelection) {
+      var word = editor.document.getText(expandedSelection);
+      if (word) {
+        caniuse.retrieveInformation(caniuse.getNormalizedRule(word).toLowerCase(), showOutput);
+      }
+    }
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+(function(angular) {
+  'use strict';
+
+  angular.module('chrome').factory('historyService', historyService);
+
+  function historyService($q, sharedService) {
+    return {
+      historyList: historyList,
+      getVisits: getVisits,
+      monitorHistory: monitorHistory
+    };
+
+    function historyList(param) {
+      var chromeParam = {};
+      chromeParam.text = param.searchText;
+      chromeParam.startTime = param.startDate;
+      chromeParam.maxResults = param.maxResults;
+      var deferred = $q.defer();
+      chrome.history.search(chromeParam, function(response) {
+        var list = sharedService.populateList(response);
+        deferred.resolve(list);
+      });
+      return deferred.promise;
+    }
+
+    function getVisits(url) {
+      var deferred = $q.defer();
+      chrome.history.getVisits({ url: url }, function(visits) {
+        deferred.resolve(visits);
+      });
+      return deferred.promise;
+    }
+
+    function monitorHistory(addHistoryCB) {
+      chrome.history.onVisited.addListener(function(historyItem) {
+        addHistoryCB(historyItem);
+      });
+    }
+  }
+})(angular);
+
+const options = {
+  method: 'GET',
+  uri: 'https://api.github.com/com/search/repositores',
+  headers: {
+    'User-Agent': 'gittr-cli'
+  },
+  qs: { q: `language:${argv.lang}`, sort: 'stars' }
+};

--- a/demo/sample.tsx
+++ b/demo/sample.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+
+interface Sample {
+  type: string | undefined;
+  name?: string;
+  click(): void;
+  callback: () => void;
+}
+
+type SampleType = {
+  myType: string;
+};
+
+export class Test extends React.Component<{ bar: string }, {}> {
+  render() {
+    return (
+      <div foo={this.props.bar} bar={true} baz={"str"} boz={"other str"} />
+    );
+  }
+}
+
+import * as styles from "./mission.scss";
+
+export default function MissionIcon({ key, title }) {
+  return (
+    <i
+      class={classnames(styles["mission__icon"], {
+        [styles["mission__icon-letter"]]: title.match(A_HEBREW_LETTER),
+        [styles["mission__icon-first"]]: !key
+      })}
+    >
+      {title}
+    </i>
+  );
+}
+
+@connect(
+  ({ artists }) => ({ artists }),
+  dispatch =>
+    bindActionCreators(
+      { getArtists, getArtist, addArtist, editArtist, removeArtist },
+      dispatch
+    )
+)
+export default class AdminArtists extends Component {
+  componentWillMount = () => {
+    this.props.getArtists();
+  };
+
+  render = () => {
+    console.log(this.props.artists);
+    return <div />;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,15 @@
   ],
   "contributes": {
     "themes": [{
-      "label": "Subliminal",
-      "uiTheme": "vs-dark",
-      "path": "./themes/Subliminal-color-theme.json"
-    }]
+        "label": "Subliminal",
+        "uiTheme": "vs-dark",
+        "path": "./themes/Subliminal-color-theme.json"
+      },
+      {
+        "label": "Subliminal Operator",
+        "uiTheme": "vs-dark",
+        "path": "./themes/Subliminal-operator-theme.json"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,7 @@
     "vscode": "^1.22.0"
   },
   "icon": "icon.png",
-  "keywords": [
-    "theme",
-    "minimal",
-    "oceanic",
-    "dark",
-    "sublime"
-  ],
+  "keywords": ["theme", "minimal", "oceanic", "dark", "sublime"],
   "repository": {
     "type": "git",
     "url": "https://github.com/gaearon/subliminal.git"
@@ -24,16 +18,12 @@
   "bugs": {
     "url": "https://github.com/gaearon/subliminal/issues"
   },
-  "categories": [
-    "Themes"
-  ],
+  "categories": ["Themes"],
   "contributes": {
-    "themes": [
-      {
-        "label": "Subliminal",
-        "uiTheme": "vs-dark",
-        "path": "./themes/Subliminal-color-theme.json"
-      }
-    ]
+    "themes": [{
+      "label": "Subliminal",
+      "uiTheme": "vs-dark",
+      "path": "./themes/Subliminal-color-theme.json"
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
     "vscode": "^1.22.0"
   },
   "icon": "icon.png",
-  "keywords": ["theme", "minimal", "oceanic", "dark", "sublime"],
+  "keywords": [
+    "theme",
+    "minimal",
+    "oceanic",
+    "dark",
+    "sublime"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/gaearon/subliminal.git"
@@ -18,7 +24,9 @@
   "bugs": {
     "url": "https://github.com/gaearon/subliminal/issues"
   },
-  "categories": ["Themes"],
+  "categories": [
+    "Themes"
+  ],
   "contributes": {
     "themes": [{
       "label": "Subliminal",

--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -246,13 +246,31 @@
       }
     },
     {
-      "scope": "source.js entity.other.attribute-name.js",
-      "settings": {
-        "fontStyle": "italic"
-      }
-    },
-    {
-      "scope": "text.html.basic entity.other.attribute-name.html",
+      "name": "Italic font style",
+      "scope": [
+        "entity.name.function.ts",
+        "entity.name.function.tsx",
+        "support.type.primitive",
+        "entity.other.attribute-name",
+        "entity.name.tag.custom",
+        "source.js.jsx keyword.control.flow.js",
+        "support.type.property.css",
+        "support.function.basic_functions",
+        "variable.assignment.coffee",
+        "support.function.basic_functions",
+        "keyword.operator.type.annotation",
+        "punctuation.section.embedded",
+        "assignment.coffee",
+        "entity.name.type.ts",
+        "italic",
+        "quote",
+        "type .function",
+        "type.function",
+        "storage.type.class",
+        "keyword.control",
+        "modifier",
+        "this"
+      ],
       "settings": {
         "fontStyle": "italic"
       }

--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -275,7 +275,6 @@
         "variable.assignment.coffee",
         "support.function.basic_functions",
         "keyword.operator.type.annotation",
-        "punctuation.section.embedded",
         "assignment.coffee",
         "italic",
         "quote",

--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -380,7 +380,10 @@
       }
     },
     {
-      "scope": "text.html.basic entity.other.attribute-name.html",
+      "scope": [
+        "text.html.basic entity.other.attribute-name.html",
+        "entity.other.attribute-name"
+      ],
       "settings": {
         "fontStyle": "italic"
       }

--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -1,4 +1,5 @@
 {
+  "name": "Subliminal",
   "type": "dark",
   "colors": {
     // Based on One Dark + Oceanic Next
@@ -109,36 +110,41 @@
       }
     },
     {
-      "name": "Flow Typedef",
-      "scope": "meta.type.flowtype.js variable.other.flowtype.js",
+      "name": "Flow/TypeScript Typedef",
+      "scope":
+        "meta.type.flowtype.js variable.other.flowtype.js, entity.name.type.ts, entity.name.type.tsx",
       "settings": {
         "foreground": "#d4d4d4"
       }
     },
     {
       "name": "Keyword",
-      "scope": "keyword, storage.type.js, storage.type.function.js, variable.other.flowtype.js, storage.type.extends.js, storage.type.function.js, storage.type.class.js",
+      "scope":
+        "keyword, storage.type.js, storage.type.ts, storage.type.tsx, storage.type.function.js, storage.type.function.ts, storage.type.function.tsx, variable.other.flowtype.js, storage.type.extends.js, storage.type.extends.ts, storage.type.extends.tsx, storage.type.class.js, storage.type.class.ts, storage.type.class.tsx",
       "settings": {
         "foreground": "#7F7F7F"
       }
     },
     {
       "name": "Function Call",
-      "scope": "variable.function.js, meta.class meta.group.braces.curly meta.function-call variable.function.js, entity.name.tag.jsx, variable.function.constructor.js",
+      "scope":
+        "variable.function.js, variable.function.ts, variable.function.tsx, meta.class meta.group.braces.curly meta.function-call variable.function.js, meta.class meta.group.braces.curly meta.function-call variable.function.ts, meta.class meta.group.braces.curly meta.function-call variable.function.tsx, entity.name.tag.jsx, entity.name.tag.tsx, variable.function.constructor.js, variable.function.constructor.ts, variable.function.constructor.tsx",
       "settings": {
         "foreground": "#ffe2a9"
       }
     },
     {
       "name": "Function/Class Name",
-      "scope": "entity.name.function.js, meta.class.js entity.name.class, meta.class meta.function-call variable.function.js, source.js keyword.control.loop.js, storage.type.function.arrow.js",
+      "scope":
+        "entity.name.function.js, entity.name.function.ts, entity.name.function.tsx, meta.class.js entity.name.class, meta.class.ts entity.name.class, meta.class.tsx entity.name.class, meta.class meta.function-call variable.function.js, meta.class meta.function-call variable.function.ts, meta.class meta.function-call variable.function.tsx, source.js keyword.control.loop.js, source.ts keyword.control.loop.ts, source.tsx keyword.control.loop.tsx, storage.type.function.arrow.js, storage.type.function.arrow.ts, storage.type.function.arrow.tsx",
       "settings": {
         "foreground": "#f1a5ab"
       }
     },
     {
       "name": "Control Flow",
-      "scope": "keyword.control.flow.js, keyword.control.trycatch.js, source.js meta.group.braces.curly.js keyword.control.loop.js, keyword.control.switch.js",
+      "scope":
+        "keyword.control.flow.js, keyword.control.flow.ts, keyword.control.flow.tsx, keyword.control.trycatch.js, keyword.control.trycatch.ts, keyword.control.trycatch.tsx, source.js meta.group.braces.curly.js keyword.control.loop.js, source.ts meta.group.braces.curly.ts keyword.control.loop.ts, source.tsx meta.group.braces.curly.tsx keyword.control.loop.tsx, keyword.control.switch.js, keyword.control.switch.ts, keyword.control.switch.tsx",
       "settings": {
         "foreground": "#f1a5ab"
       }
@@ -152,14 +158,16 @@
     },
     {
       "name": "Logic",
-      "scope": "keyword.operator.logical.js",
+      "scope":
+        "keyword.operator.logical.js, keyword.operator.logical.ts, keyword.operator.logical.tsx",
       "settings": {
         "foreground": "#ffe2a9"
       }
     },
     {
       "name": "Comparison",
-      "scope": "keyword.operator.comparison.js, keyword.operator.relational.js",
+      "scope":
+        "keyword.operator.comparison.js, keyword.operator.comparison.ts, keyword.operator.comparison.tsx, keyword.operator.relational.js, keyword.operator.relational.ts, keyword.operator.relational.tsx",
       "settings": {
         "foreground": "#f1a5ab"
       }
@@ -173,7 +181,8 @@
     },
     {
       "name": "Literal",
-      "scope": "constant.language, constant.numeric, support.constant, constant.character, constant.other.color, constant.other.symbol, constant.other.key, keyword.other.unit",
+      "scope":
+        "constant.language, constant.numeric, support.constant, constant.character, constant.other.color, constant.other.symbol, constant.other.key, keyword.other.unit",
       "settings": {
         "foreground": "#91c5d3"
       }
@@ -262,6 +271,7 @@
         "punctuation.section.embedded",
         "assignment.coffee",
         "entity.name.type.ts",
+        "entity.name.type.tsx",
         "italic",
         "quote",
         "type .function",

--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -128,7 +128,7 @@
     {
       "name": "Function Call",
       "scope":
-        "variable.function.js, variable.function.ts, variable.function.tsx, meta.class meta.group.braces.curly meta.function-call variable.function.js, meta.class meta.group.braces.curly meta.function-call variable.function.ts, meta.class meta.group.braces.curly meta.function-call variable.function.tsx, entity.name.tag.jsx, entity.name.tag.tsx, variable.function.constructor.js, variable.function.constructor.ts, variable.function.constructor.tsx",
+        "variable.function.js, meta.function-call.ts entity.name.function.ts, meta.function-call.tsx entity.name.function.tsx, meta.class meta.group.braces.curly meta.function-call variable.function.js, meta.class meta.group.braces.curly meta.function-call variable.function.ts, meta.class meta.group.braces.curly meta.function-call variable.function.tsx, entity.name.tag.jsx, entity.name.tag.tsx, variable.function.constructor.js, variable.function.constructor.ts, variable.function.constructor.tsx",
       "settings": {
         "foreground": "#ffe2a9"
       }
@@ -136,7 +136,7 @@
     {
       "name": "Function/Class Name",
       "scope":
-        "entity.name.function.js, entity.name.function.ts, entity.name.function.tsx, meta.class.js entity.name.class, meta.class.ts entity.name.class, meta.class.tsx entity.name.class, meta.class meta.function-call variable.function.js, meta.class meta.function-call variable.function.ts, meta.class meta.function-call variable.function.tsx, source.js keyword.control.loop.js, source.ts keyword.control.loop.ts, source.tsx keyword.control.loop.tsx, storage.type.function.arrow.js, storage.type.function.arrow.ts, storage.type.function.arrow.tsx",
+        "entity.name.function.js, entity.name.function.ts, entity.name.function.tsx, meta.class.js entity.name.class, meta.class.ts entity.name.type.class, meta.class.tsx entity.name.type.class, meta.class meta.function-call variable.function.js, meta.class meta.function-call variable.function.ts, meta.class meta.function-call variable.function.tsx, source.js keyword.control.loop.js, source.ts keyword.control.loop.ts, source.tsx keyword.control.loop.tsx, storage.type.function.arrow.js, storage.type.function.arrow.ts, storage.type.function.arrow.tsx",
       "settings": {
         "foreground": "#f1a5ab"
       }
@@ -257,11 +257,18 @@
     {
       "name": "Italic font style",
       "scope": [
-        "entity.name.function.ts",
-        "entity.name.function.tsx",
+        "entity.name.type.ts",
+        "entity.name.type.tsx",
+        "entity.name.tag.doctype",
+        "meta.tag.sgml.doctype",
+        "meta.tag.sgml.doctype.html",
+        "markup.italic.markdown",
+        "markup.quote.markdown",
         "support.type.primitive",
         "entity.other.attribute-name",
         "entity.name.tag.custom",
+        "source.js entity.other.attribute-name.js",
+        "ext.html.basic entity.other.attribute-name.html",
         "source.js.jsx keyword.control.flow.js",
         "support.type.property.css",
         "support.function.basic_functions",
@@ -270,19 +277,28 @@
         "keyword.operator.type.annotation",
         "punctuation.section.embedded",
         "assignment.coffee",
-        "entity.name.type.ts",
-        "entity.name.type.tsx",
         "italic",
         "quote",
         "type .function",
         "type.function",
         "storage.type.class",
-        "keyword.control",
         "modifier",
+        "keyword.control",
         "this"
       ],
       "settings": {
         "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Normal font style",
+      "scope": [
+        "keyword.control.import",
+        "keyword.control.export",
+        "keyword.control.flow"
+      ],
+      "settings": {
+        "fontStyle": "normal"
       }
     }
   ]

--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -118,7 +118,14 @@
     },
     {
       "name": "TypeScript Typedef",
-      "scope": ["entity.name.type.ts", "entity.name.type.tsx"],
+      "scope": [
+        "entity.name.type.ts",
+        "entity.name.type.tsx",
+        "meta.interface.ts variable.object.property.ts",
+        "meta.interface.tsx variable.object.property.tsx",
+        "meta.type.declaration.ts variable.object.property.ts",
+        "meta.type.declaration.tsx variable.object.property.tsx"
+      ],
       "settings": {
         "foreground": "#d4d4d4"
       }
@@ -147,8 +154,18 @@
         "storage.type.function.tsx",
         "storage.type.extends.ts",
         "storage.type.extends.tsx",
+        "storage.type.type.ts",
+        "storage.type.type.tsx",
+        "storage.type.interface.ts",
+        "storage.type.interface.tsx",
         "storage.type.class.ts",
-        "storage.type.class.tsx"
+        "storage.type.class.tsx",
+        "storage.modifier.ts",
+        "storage.modifier.tsx",
+        "constant.language.import-export-all.ts",
+        "constant.language.import-export-all.tsx",
+        "variable.object.property.ts",
+        "variable.object.property.tsx"
       ],
       "settings": {
         "foreground": "#7F7F7F"
@@ -169,6 +186,8 @@
     {
       "name": "Function Call - TypeScript",
       "scope": [
+        "support.function.ts",
+        "support.function.tsx",
         "meta.function-call.ts entity.name.function.ts",
         "meta.function-call.tsx entity.name.function.tsx",
         "meta.class meta.group.braces.curly meta.function-call variable.function.ts",
@@ -233,6 +252,8 @@
         "keyword.control.trycatch.tsx",
         "source.ts meta.group.braces.curly.ts keyword.control.loop.ts",
         "source.tsx meta.group.braces.curly.tsx keyword.control.loop.tsx",
+        "source.ts meta.export.default.ts keyword.control.default.ts",
+        "source.tsx meta.export.default.tsx keyword.control.default.tsx",
         "keyword.control.switch.ts",
         "keyword.control.switch.tsx"
       ],
@@ -281,6 +302,25 @@
       ],
       "settings": {
         "foreground": "#f1a5ab"
+      }
+    },
+    {
+      "name": "HTML Tag names",
+      "scope": [
+        "entity.name.tag support.class.component",
+        "meta.tag.other.html",
+        "meta.tag.other.js",
+        "meta.tag.other.jsx",
+        "meta.tag.other.tsx",
+        "entity.name.tag.tsx",
+        "entity.name.tag.jsx",
+        "entity.name.tag.js",
+        "entity.name.tag",
+        "meta.tag.js",
+        "meta.tag.html"
+      ],
+      "settings": {
+        "foreground": "#ffe2a9"
       }
     },
     {

--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -295,7 +295,8 @@
       "scope": [
         "keyword.control.import",
         "keyword.control.export",
-        "keyword.control.flow"
+        "keyword.control.flow",
+        "keyword.control.from"
       ],
       "settings": {
         "fontStyle": "normal"

--- a/themes/Subliminal-operator-theme.json
+++ b/themes/Subliminal-operator-theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "Subliminal",
+  "name": "Subliminal Operator",
   "type": "dark",
   "colors": {
     // Based on One Dark + Oceanic Next
@@ -100,8 +100,7 @@
     "titleBar.inactiveBackground": "#1c1f26",
     "widget.shadow": "#282c35"
   },
-  "tokenColors": [
-    {
+  "tokenColors": [{
       "name": "Comments",
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
@@ -242,7 +241,7 @@
     },
     {
       "name": "Assignment",
-      "scope": ["keyword.operator.assignment"],
+      "scope": "keyword.operator.assignment",
       "settings": {
         "foreground": "#ffe2a9"
       }
@@ -256,7 +255,10 @@
     },
     {
       "name": "Logic - TypeScript",
-      "scope": ["keyword.operator.logical.ts", "keyword.operator.logical.tsx"],
+      "scope": [
+        "keyword.operator.logical.ts",
+        "keyword.operator.logical.tsx"
+      ],
       "settings": {
         "foreground": "#ffe2a9"
       }
@@ -309,42 +311,42 @@
 
     {
       "name": "Inserted",
-      "scope": ["markup.inserted"],
+      "scope": "markup.inserted",
       "settings": {
         "foreground": "#99C794"
       }
     },
     {
       "name": "Deleted",
-      "scope": ["markup.deleted"],
+      "scope": "markup.deleted",
       "settings": {
         "foreground": "#E15A60"
       }
     },
     {
       "name": "Changed",
-      "scope": ["markup.changed"],
+      "scope": "markup.changed",
       "settings": {
         "foreground": "#BB80B3"
       }
     },
     {
       "name": "URL",
-      "scope": ["*url*", "*link*", "*uri*"],
+      "scope": "*url*, *link*, *uri*",
       "settings": {
         "fontStyle": "underline"
       }
     },
     {
       "name": "Search Results Nums",
-      "scope": ["constant.numeric.line-number.find-in-files - match"],
+      "scope": "constant.numeric.line-number.find-in-files - match",
       "settings": {
         "foreground": "#AB7967"
       }
     },
     {
       "name": "Search Results Lines",
-      "scope": ["entity.name.filename.find-in-files"],
+      "scope": "entity.name.filename.find-in-files",
       "settings": {
         "foreground": "#99C794"
       }
@@ -374,15 +376,51 @@
       }
     },
     {
-      "scope": "source.js entity.other.attribute-name.js",
+      "name": "Italic font style",
+      "scope": [
+        "entity.name.type.ts",
+        "entity.name.type.tsx",
+        "entity.name.tag.doctype",
+        "meta.tag.sgml.doctype",
+        "meta.tag.sgml.doctype.html",
+        "markup.italic.markdown",
+        "markup.quote.markdown",
+        "support.type.primitive",
+        "entity.other.attribute-name",
+        "entity.name.tag.custom",
+        "source.js entity.other.attribute-name.js",
+        "ext.html.basic entity.other.attribute-name.html",
+        "source.js.jsx keyword.control.flow.js",
+        "support.type.property.css",
+        "support.function.basic_functions",
+        "variable.assignment.coffee",
+        "support.function.basic_functions",
+        "keyword.operator.type.annotation",
+        "assignment.coffee",
+        "italic",
+        "quote",
+        "type .function",
+        "type.function",
+        "storage.modifier.js",
+        "storage.type.class",
+        "modifier",
+        "keyword.control",
+        "this"
+      ],
       "settings": {
         "fontStyle": "italic"
       }
     },
     {
-      "scope": "text.html.basic entity.other.attribute-name.html",
+      "name": "Normal font style",
+      "scope": [
+        "keyword.control.import",
+        "keyword.control.export",
+        "keyword.control.flow",
+        "keyword.control.from"
+      ],
       "settings": {
-        "fontStyle": "italic"
+        "fontStyle": "normal"
       }
     }
   ]

--- a/themes/Subliminal-operator-theme.json
+++ b/themes/Subliminal-operator-theme.json
@@ -100,7 +100,8 @@
     "titleBar.inactiveBackground": "#1c1f26",
     "widget.shadow": "#282c35"
   },
-  "tokenColors": [{
+  "tokenColors": [
+    {
       "name": "Comments",
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
@@ -117,7 +118,14 @@
     },
     {
       "name": "TypeScript Typedef",
-      "scope": ["entity.name.type.ts", "entity.name.type.tsx"],
+      "scope": [
+        "entity.name.type.ts",
+        "entity.name.type.tsx",
+        "meta.interface.ts variable.object.property.ts",
+        "meta.interface.tsx variable.object.property.tsx",
+        "meta.type.declaration.ts variable.object.property.ts",
+        "meta.type.declaration.tsx variable.object.property.tsx"
+      ],
       "settings": {
         "foreground": "#d4d4d4"
       }
@@ -146,8 +154,18 @@
         "storage.type.function.tsx",
         "storage.type.extends.ts",
         "storage.type.extends.tsx",
+        "storage.type.type.ts",
+        "storage.type.type.tsx",
+        "storage.type.interface.ts",
+        "storage.type.interface.tsx",
         "storage.type.class.ts",
-        "storage.type.class.tsx"
+        "storage.type.class.tsx",
+        "storage.modifier.ts",
+        "storage.modifier.tsx",
+        "constant.language.import-export-all.ts",
+        "constant.language.import-export-all.tsx",
+        "variable.object.property.ts",
+        "variable.object.property.tsx"
       ],
       "settings": {
         "foreground": "#7F7F7F"
@@ -158,7 +176,6 @@
       "scope": [
         "variable.function.js",
         "meta.class meta.group.braces.curly meta.function-call variable.function.js",
-        "entity.name.tag.jsx",
         "variable.function.constructor.js"
       ],
       "settings": {
@@ -168,11 +185,12 @@
     {
       "name": "Function Call - TypeScript",
       "scope": [
+        "support.function.ts",
+        "support.function.tsx",
         "meta.function-call.ts entity.name.function.ts",
         "meta.function-call.tsx entity.name.function.tsx",
         "meta.class meta.group.braces.curly meta.function-call variable.function.ts",
         "meta.class meta.group.braces.curly meta.function-call variable.function.tsx",
-        "entity.name.tag.tsx",
         "variable.function.constructor.ts",
         "variable.function.constructor.tsx"
       ],
@@ -232,6 +250,8 @@
         "keyword.control.trycatch.tsx",
         "source.ts meta.group.braces.curly.ts keyword.control.loop.ts",
         "source.tsx meta.group.braces.curly.tsx keyword.control.loop.tsx",
+        "source.ts meta.export.default.ts keyword.control.default.ts",
+        "source.tsx meta.export.default.tsx keyword.control.default.tsx",
         "keyword.control.switch.ts",
         "keyword.control.switch.tsx"
       ],
@@ -255,10 +275,7 @@
     },
     {
       "name": "Logic - TypeScript",
-      "scope": [
-        "keyword.operator.logical.ts",
-        "keyword.operator.logical.tsx"
-      ],
+      "scope": ["keyword.operator.logical.ts", "keyword.operator.logical.tsx"],
       "settings": {
         "foreground": "#ffe2a9"
       }
@@ -283,6 +300,25 @@
       ],
       "settings": {
         "foreground": "#f1a5ab"
+      }
+    },
+    {
+      "name": "HTML Tag names",
+      "scope": [
+        "entity.name.tag support.class.component",
+        "meta.tag.other.html",
+        "meta.tag.other.js",
+        "meta.tag.other.jsx",
+        "meta.tag.other.tsx",
+        "entity.name.tag.tsx",
+        "entity.name.tag.jsx",
+        "entity.name.tag.js",
+        "entity.name.tag",
+        "meta.tag.js",
+        "meta.tag.html"
+      ],
+      "settings": {
+        "foreground": "#ffe2a9"
       }
     },
     {


### PR DESCRIPTION
In my last PR #5 I've added TypeScript support to subliminal.

In this PR I have done some refactoring

- TypeScript .ts / .tsx support
- Preserved the original Subliminal theme 
- Reformatted the long selection strings to arrays
- Separated some scopes into language groups (would enable different colors for different languages)
- Added extra theme for more italic / operator style
- Added demo files

**TypeScript before**
![ts before](https://user-images.githubusercontent.com/10043789/39663865-d183f064-507a-11e8-8d2e-43876a710b52.png)

**TypeScript after**
![ts before](https://user-images.githubusercontent.com/10043789/39663864-d169fdda-507a-11e8-93b2-36f83d441575.png)

The screens are based on the `Subliminal Operator` theme. In the original theme the italic style style is kept to a minimum.

Fixes #19 #4 

**EDIT**:

- Improved TypeScript colors
- HTML Support

**TypeScript ts / tsx**
![subliminal-actual-tsx](https://user-images.githubusercontent.com/10043789/39889880-67080842-5499-11e8-94bd-4a482354410b.png)

**HTML before**
![subliminal_html_before](https://user-images.githubusercontent.com/10043789/39889901-773d6ad6-5499-11e8-9844-676a04499a3d.png)

**HTML after**
![subliminal_html_after](https://user-images.githubusercontent.com/10043789/39889917-7fa48d3a-5499-11e8-8872-ae1af27716c1.png)


