### PR TITLE
Add unused variables color

### DIFF
--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -73,7 +73,7 @@
     "editorGroupHeader.tabsBorder": "#282c35",
     "editorGroupHeader.tabsBackground": "#1c1f26",
     "editorGutter.background": "#282c35",
-    "editorUnnecessary.foreground": "#7f7f7f",
+    "editorUnnecessaryCode.opacity": "#00000088",
     "gitDecoration.ignoredResourceForeground": "#64727f",
     "list.activeSelectionBackground": "#343d46",
     "list.activeSelectionForeground": "#dfe1e8",

--- a/themes/Subliminal-color-theme.json
+++ b/themes/Subliminal-color-theme.json
@@ -73,6 +73,7 @@
     "editorGroupHeader.tabsBorder": "#282c35",
     "editorGroupHeader.tabsBackground": "#1c1f26",
     "editorGutter.background": "#282c35",
+    "editorUnnecessary.foreground": "#7f7f7f",
     "gitDecoration.ignoredResourceForeground": "#64727f",
     "list.activeSelectionBackground": "#343d46",
     "list.activeSelectionForeground": "#dfe1e8",


### PR DESCRIPTION
VS Code now supports [unused variable detection](https://code.visualstudio.com/updates/v1_24#_highlight-unused-variables-and-imports)

I've added a color to support this new feature. It matches comment's color.

Before:
<img width="224" alt="before" src="https://user-images.githubusercontent.com/867546/41193567-8c5dea00-6c16-11e8-94df-4651cab4fead.png">

After:
<img width="224" alt="after" src="https://user-images.githubusercontent.com/867546/41193568-92b42590-6c16-11e8-8223-cd7ebeca647e.png">
